### PR TITLE
Add npm install & build PDFs to setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ $ rake server
 
 You can then view the site as <http://localhost:4567>
 
+To build the PDF versions of all songs to the `build/pdfs` directory:
+
+```bash
+$ bundle exec middleman build
+```
+
 ## Deployment
 
 To deploy, first create an `.s3_sync` file with the following:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ To set up the project, do the following:
 $ git clone git@github.com:spilth/mss.nyc.git
 $ cd mss.nyc
 $ bundle
+$ npm install
 $ rake server
 ```
 


### PR DESCRIPTION
I got the site and PDF builder running locally, but I needed a few more commands to get everything working. See diffs below for extra instructions that would have been helpful in the README